### PR TITLE
Fix Wagtail RemovedInWagtail60 deprecation warning

### DIFF
--- a/src/wagtail_model_forms/wagtail_hooks.py
+++ b/src/wagtail_model_forms/wagtail_hooks.py
@@ -18,7 +18,7 @@ if REPORTS:
         return ReportsMenuItem(
             FormSubmissionReportView.title,
             reverse("form_submissions_report"),
-            classnames="icon icon-" + FormSubmissionReportView.header_icon,
+            classname="icon icon-" + FormSubmissionReportView.header_icon,
             order=700,
         )
 


### PR DESCRIPTION
> RemovedInWagtail60Warning: The `classnames` kwarg for MenuItem is
> deprecated - use `classname` instead

:Ref: https://docs.wagtail.org/en/stable/releases/5.2.html#adoption-of-classname-convention-for-menuitem-related-classes-and-hooks